### PR TITLE
Add team dashboard downloader utilities

### DIFF
--- a/01_data_scrapping/01a_scripts/_01a_function_tools.py
+++ b/01_data_scrapping/01a_scripts/_01a_function_tools.py
@@ -7,6 +7,7 @@ import pandas as pd
 from nba_api.stats import endpoints as ep
 from nba_api.stats.endpoints import LeagueGameLog
 from nba_api.stats.library.parameters import SeasonTypeAllStar
+from nba_api.stats.static import teams as static_teams
 
 # --- Logger ---
 logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
@@ -22,6 +23,20 @@ BOX_ENDPOINTS = [
     ("boxscore_matchups_v3", "BoxScoreMatchupsV3"),
     ("boxscore_summary_v2", "BoxScoreSummaryV2"),
     # OJO: NO incluimos "BoxScoreSimilarityScore"
+]
+
+
+TEAM_DASH_ENDPOINTS = [
+    ("team_player_dashboard", "TeamPlayerDashboard"),
+    ("team_player_on_off_details", "TeamPlayerOnOffDetails"),
+    ("team_player_on_off_summary", "TeamPlayerOnOffSummary"),
+    ("team_vs_player", "TeamVsPlayer"),
+    ("team_dash_lineups", "TeamDashLineups"),
+    ("team_dash_pt_pass", "TeamDashPtPass"),
+    ("team_dash_pt_reb", "TeamDashPtReb"),
+    ("team_dash_pt_shots", "TeamDashPtShots"),
+    ("team_dashboard_by_general_splits", "TeamDashboardByGeneralSplits"),
+    ("team_dashboard_by_shooting_splits", "TeamDashboardByShootingSplits"),
 ]
 
 def _get_endpoint_class(class_name: str):
@@ -45,6 +60,13 @@ def list_game_ids(season: str, include_playoffs: bool = False):
     # Únicos
     return list(dict.fromkeys(game_ids))
 
+
+def list_team_ids() -> list[int]:
+    """Devuelve los IDs de los equipos NBA (solo franquicias activas)."""
+
+    teams = static_teams.get_teams()
+    return [team["id"] for team in teams if team.get("is_nba_team")]
+
 def fetch_endpoint_df(endpoint_class_name: str, game_id: str, max_retries: int = 3, sleep: float = 0.8) -> pd.DataFrame:
     """Descarga un DataFrame de un endpoint concreto para un GAME_ID."""
     cls = _get_endpoint_class(endpoint_class_name)
@@ -64,25 +86,98 @@ def fetch_endpoint_df(endpoint_class_name: str, game_id: str, max_retries: int =
     logging.error(f"No se pudo descargar {endpoint_class_name} para {game_id}")
     return pd.DataFrame()
 
+
+def fetch_team_endpoint_tables(
+    endpoint_class_name: str,
+    *,
+    team_id: int,
+    season: str,
+    season_type: str,
+    max_retries: int = 3,
+    sleep: float = 0.8,
+    **extra_params,
+):
+    """Descarga todas las tablas disponibles para un endpoint de dashboards de equipo."""
+
+    cls = _get_endpoint_class(endpoint_class_name)
+    if cls is None:
+        logging.warning(
+            f"[skip] Endpoint no disponible en esta versión de nba_api: {endpoint_class_name}"
+        )
+        return []
+
+    base_kwargs = {"team_id": team_id, "season": season}
+    base_kwargs.update(extra_params)
+
+    for attempt in range(max_retries):
+        try:
+            try:
+                resp = cls(
+                    season_type_all_star=season_type,
+                    **base_kwargs,
+                )
+            except TypeError:
+                resp = cls(
+                    season_type=season_type,
+                    **base_kwargs,
+                )
+
+            tables = []
+            for index, dataset in enumerate(getattr(resp, "data_sets", []) or []):
+                dataset_name = getattr(dataset, "name", f"dataset_{index}")
+                if hasattr(dataset, "get_data_frame"):
+                    df = dataset.get_data_frame()
+                else:
+                    df = pd.DataFrame(dataset)
+                tables.append((dataset_name, df))
+            return tables
+        except Exception as e:
+            logging.warning(
+                (
+                    f"Fallo en {endpoint_class_name} para team_id={team_id}, "
+                    f"season={season}, season_type={season_type} "
+                    f"(intento {attempt + 1}/{max_retries}): {e}"
+                )
+            )
+            time.sleep(sleep * (attempt + 1))
+
+    logging.error(
+        f"No se pudo descargar {endpoint_class_name} para team_id={team_id} en {season} ({season_type})"
+    )
+    return []
+
 def save_parquet(
     df: pd.DataFrame,
     path: str,
-    season: str,
-    game_id: str,
-    endpoint_slug: str,
+    season: str | None = None,
+    game_id: str | None = None,
+    endpoint_slug: str | None = None,
+    **identifiers,
 ):
     """Guarda el DataFrame en parquet y devuelve metadatos útiles sobre la operación."""
 
     was_empty = df.empty
+    metadata = {}
+    if season is not None:
+        metadata["season"] = season
+    if game_id is not None:
+        metadata["game_id"] = game_id
+    if endpoint_slug is not None:
+        metadata["endpoint"] = endpoint_slug
+
+    metadata.update(identifiers)
+
     if was_empty:
+        context = ", ".join(f"{k}={v}" for k, v in metadata.items())
+        endpoint_label = endpoint_slug or "endpoint"
+        context_str = f" ({context})" if context else ""
         logging.warning(
-            f"DF vacío en {endpoint_slug} {game_id}, guardando placeholder igualmente"
+            f"DF vacío en {endpoint_label}{context_str}, guardando placeholder igualmente"
         )
 
     df_to_save = df.copy()
-    df_to_save["season"] = season
-    df_to_save["game_id"] = game_id
-    df_to_save["endpoint"] = endpoint_slug
+    for column, value in metadata.items():
+        df_to_save[column] = value
 
     os.makedirs(os.path.dirname(path), exist_ok=True)
     df_to_save.to_parquet(path, index=False)

--- a/01_data_scrapping/01a_scripts/_01a_get_team_dashboards.py
+++ b/01_data_scrapping/01a_scripts/_01a_get_team_dashboards.py
@@ -1,0 +1,235 @@
+import os
+import re
+import argparse
+import logging
+
+from nba_api.stats.library.parameters import SeasonTypeAllStar
+
+from _01a_function_tools import (
+    TEAM_DASH_ENDPOINTS,
+    list_team_ids,
+    fetch_team_endpoint_tables,
+    save_parquet,
+)
+
+# Ruta base donde guardar (misma que otros scripts)
+OUTPUT_ROOT = "/Users/pablo/Documents/BigData/BasketballAnalysis/00_data/00a_raw"
+
+logger = logging.getLogger(__name__)
+
+STATUS_META = {
+    "saved": ("💾", "Guardado"),
+    "exists": ("⏭", "Ya existía"),
+    "empty": ("⚠️", "Sin datos"),
+}
+
+
+def _slugify_dataset(name: str) -> str:
+    slug = re.sub(r"[^0-9a-zA-Z]+", "_", name).strip("_").lower()
+    return slug or "dataset"
+
+
+def _print_team_summary(
+    *,
+    season: str,
+    season_type: str,
+    team_index: int,
+    total_teams: int,
+    team_id: int,
+    statuses: list,
+    teams_with_new_data: int,
+):
+    """Muestra un bloque resumen visual para cada equipo procesado."""
+
+    total_entries = len(statuses)
+    new_files = sum(
+        1
+        for status in statuses
+        if status["status"] in {"saved", "empty"} and status.get("path")
+    )
+    existing_files = sum(1 for status in statuses if status["status"] == "exists")
+    warnings = sum(1 for status in statuses if status["status"] == "empty")
+
+    header = (
+        f"Temporada {season} · {season_type} · Equipo {team_index}/{total_teams} "
+        f"· TEAM_ID {team_id}"
+    )
+    line_length = max(len(header), 80)
+    border = "─" * line_length
+    progress_pct = (team_index / total_teams * 100) if total_teams else 100
+
+    print("\n" + border)
+    print(header)
+    print(border)
+
+    for status in statuses:
+        icon, label = STATUS_META.get(status["status"], ("•", status["status"]))
+        rel_path = status.get("rel_path", status.get("path", ""))
+        dataset_label = status.get("dataset")
+        detail_slug = status["slug"] if dataset_label is None else f"{status['slug']} · {dataset_label}"
+        if status["status"] in {"saved", "empty"}:
+            rows = status.get("rows", 0)
+            detail = f"{detail_slug} ({rows} filas) → {rel_path}"
+        elif status["status"] == "exists":
+            detail = f"{detail_slug} (ya estaba)"
+        else:
+            detail = detail_slug
+        print(f"  {icon} {label:<11} {detail}")
+
+    summary_parts = [
+        f"Tablas listas: {total_entries}/{total_entries}",
+        f"Nuevos archivos: {new_files}",
+        f"Ya existentes: {existing_files}",
+        f"Equipos con nuevos datos: {teams_with_new_data}",
+        f"Progreso etapa: {progress_pct:.1f}%",
+    ]
+    if warnings:
+        summary_parts.insert(2, f"Sin datos: {warnings}")
+
+    print("Resumen → " + " | ".join(summary_parts))
+    print(border)
+
+
+def process_season(
+    season: str,
+    include_playoffs: bool = False,
+    sleep: float = 0.8,
+    max_retries: int = 3,
+):
+    team_ids = sorted(list_team_ids())
+    if not team_ids:
+        logger.warning("No se encontraron equipos NBA para procesar")
+        return
+
+    season_types = [SeasonTypeAllStar.regular]
+    if include_playoffs:
+        season_types.append(SeasonTypeAllStar.playoffs)
+
+    total_teams = len(team_ids)
+
+    for season_type in season_types:
+        logger.info(
+            f"{season} ({season_type}): procesando {total_teams} equipos · {len(TEAM_DASH_ENDPOINTS)} endpoints"
+        )
+
+        teams_with_new_data = 0
+
+        for index, team_id in enumerate(team_ids, start=1):
+            statuses = []
+
+            for slug, class_name in TEAM_DASH_ENDPOINTS:
+                tables = fetch_team_endpoint_tables(
+                    class_name,
+                    team_id=team_id,
+                    season=season,
+                    season_type=season_type,
+                    max_retries=max_retries,
+                    sleep=sleep,
+                )
+
+                if not tables:
+                    statuses.append(
+                        {
+                            "slug": slug,
+                            "dataset": None,
+                            "status": "empty",
+                            "rows": 0,
+                            "path": "",
+                            "rel_path": "",
+                        }
+                    )
+                    continue
+
+                for dataset_name, df in tables:
+                    dataset_slug = _slugify_dataset(dataset_name)
+                    out_path = os.path.join(
+                        OUTPUT_ROOT,
+                        "team_dashboard",
+                        slug,
+                        season,
+                        season_type,
+                        f"{slug}__{team_id}__{dataset_slug}.parquet",
+                    )
+                    rel_path = os.path.relpath(out_path, OUTPUT_ROOT)
+
+                    if os.path.exists(out_path):
+                        statuses.append(
+                            {
+                                "slug": slug,
+                                "dataset": dataset_name,
+                                "status": "exists",
+                                "path": out_path,
+                                "rel_path": rel_path,
+                            }
+                        )
+                        continue
+
+                    result = save_parquet(
+                        df,
+                        out_path,
+                        season=season,
+                        endpoint_slug=slug,
+                        team_id=team_id,
+                        season_type=season_type,
+                        dataset=dataset_name,
+                    )
+
+                    statuses.append(
+                        {
+                            "slug": slug,
+                            "dataset": dataset_name,
+                            "status": "empty" if result["was_empty"] else "saved",
+                            "rows": result["rows"],
+                            "path": result["path"],
+                            "rel_path": rel_path,
+                        }
+                    )
+
+            has_new_data = any(
+                status["status"] in {"saved", "empty"} and status.get("path")
+                for status in statuses
+            )
+            if has_new_data:
+                teams_with_new_data += 1
+
+            _print_team_summary(
+                season=season,
+                season_type=season_type,
+                team_index=index,
+                total_teams=total_teams,
+                team_id=team_id,
+                statuses=statuses,
+                teams_with_new_data=teams_with_new_data,
+            )
+
+        logger.info(
+            f"{season} ({season_type}): etapa completada. Equipos procesados: {total_teams}. "
+            f"Con nuevos datos en {teams_with_new_data} equipos."
+        )
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Descarga y guarda los dashboards de equipos por temporada(s)."
+    )
+    parser.add_argument("--seasons", required=True, help="Ej: '2023-24,2024-25'")
+    parser.add_argument("--include-playoffs", action="store_true")
+    parser.add_argument("--sleep", type=float, default=0.8)
+    parser.add_argument("--max-retries", type=int, default=3)
+    args = parser.parse_args()
+
+    for season in (s.strip() for s in args.seasons.split(",")):
+        if not season:
+            continue
+        process_season(
+            season=season,
+            include_playoffs=args.include_playoffs,
+            sleep=args.sleep,
+            max_retries=args.max_retries,
+        )
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+    main()
+

--- a/01_data_scrapping/01a_scripts/_01b_downloader_total.py
+++ b/01_data_scrapping/01a_scripts/_01b_downloader_total.py
@@ -24,6 +24,13 @@ TASKS = [
         "extra_args": []  # puedes poner más flags si tu script los admite
     },
 
+    {
+        "name": "Team Dashboards",
+        "rel_path": "_01a_get_team_dashboards.py",
+        "enabled": False,
+        "extra_args": [],
+    },
+
     # ======= EJEMPLOS para cuando los tengas listos =======
     # {
     #     "name": "Play-by-Play",


### PR DESCRIPTION
## Summary
- add reusable constants and helpers to fetch team dashboard endpoints, including flexible parquet saving
- implement a CLI script to download and store team dashboard datasets with progress summaries
- register the new dashboard script in the global downloader orchestrator

## Testing
- python -m py_compile 01_data_scrapping/01a_scripts/_01a_function_tools.py 01_data_scrapping/01a_scripts/_01a_get_team_dashboards.py

------
https://chatgpt.com/codex/tasks/task_e_68dbe0735f4c83209de6ea934ee6ba23