### PR TITLE
Add team boxscore download utilities and script

### DIFF
--- a/01_data_scrapping/01a_scripts/_01a_function_tools.py
+++ b/01_data_scrapping/01a_scripts/_01a_function_tools.py
@@ -3,6 +3,7 @@ import time
 import inspect
 import logging
 import pandas as pd
+from typing import Dict, Iterable, Optional
 
 # Import dinámico de endpoints para evitar fallos si alguno no existe
 from nba_api.stats import endpoints as ep
@@ -228,4 +229,274 @@ def save_parquet(
         "path": path,
         "rows": len(df_to_save),
         "was_empty": was_empty,
+    }
+
+
+BOX_SCORE_TEAM_ENDPOINT_CLASSES = [
+    "BoxScoreTraditionalV2",
+    "BoxScoreAdvancedV2",
+    "BoxScoreFourFactorsV2",
+    "BoxScoreMiscV2",
+    "BoxScoreScoringV2",
+    "BoxScoreSummaryV2",
+]
+
+
+BOX_SCORE_TEAMS_OUTPUT_ROOT = (
+    "/Users/pablo/Documents/BigData/BasketballAnalysis/00_data/00a_raw/boxscore_teams"
+)
+
+
+def _normalize_season_type_value(season_type: str) -> str:
+    """Normaliza etiquetas de ``season_type`` según los valores esperados por la API."""
+
+    if not season_type:
+        return season_type
+
+    lookup = {
+        SeasonTypeAllStar.regular.lower(): SeasonTypeAllStar.regular,
+        SeasonTypeAllStar.playoffs.lower(): SeasonTypeAllStar.playoffs,
+        SeasonTypeAllStar.pre_season.lower(): SeasonTypeAllStar.pre_season,
+        SeasonTypeAllStar.all_star.lower(): SeasonTypeAllStar.all_star,
+        "playin": "PlayIn",
+    }
+
+    normalized = season_type.strip()
+    key = normalized.lower()
+    return lookup.get(key, normalized)
+
+
+def list_team_game_ids_by_season_type(season: str, season_type: str) -> list[str]:
+    """Obtiene los ``GAME_ID`` de una temporada para equipos (``player_or_team='T'``)."""
+
+    normalized_type = _normalize_season_type_value(season_type)
+
+    try:
+        response = _call_ep(
+            LeagueGameLog,
+            season=season,
+            season_type=normalized_type,
+            player_or_team_abbreviation="T",
+        )
+    except Exception as exc:
+        logging.error(
+            f"Error listando GAME_ID para season={season}, season_type={season_type}: {exc}"
+        )
+        return []
+
+    frames = response.get_data_frames() if response else []
+    if not frames:
+        return []
+
+    df = frames[0]
+    if "GAME_ID" not in df.columns:
+        return []
+
+    return [str(gid) for gid in df["GAME_ID"].astype(str).unique().tolist()]
+
+
+def _iter_endpoint_data_sets(resp) -> Iterable[tuple[str, pd.DataFrame]]:
+    """Itera los datasets de una respuesta de ``nba_api`` devolviendo (nombre, DF)."""
+
+    for index, dataset in enumerate(getattr(resp, "data_sets", []) or []):
+        name = getattr(dataset, "name", f"dataset_{index}")
+        if hasattr(dataset, "get_data_frame"):
+            df = dataset.get_data_frame()
+        else:
+            df = pd.DataFrame(dataset)
+        yield name, df
+
+
+def _normalize_boxscore_team_columns(df: pd.DataFrame, game_id: str) -> pd.DataFrame:
+    """Asegura las columnas clave (GAME_ID, TEAM_ID, TEAM_ABBREVIATION, TEAM_NAME)."""
+
+    normalized_df = df.copy()
+
+    normalized_df["GAME_ID"] = str(game_id)
+
+    if "TEAM_ID" in normalized_df.columns:
+        normalized_df["TEAM_ID"] = normalized_df["TEAM_ID"].astype(str)
+
+    if "TEAM_ABBREVIATION" not in normalized_df.columns:
+        for candidate in [
+            "TEAM_ABBREV",
+            "TEAM_ABBREVIATION_x",
+            "TEAM_ABBREVIATION_y",
+        ]:
+            if candidate in normalized_df.columns:
+                normalized_df["TEAM_ABBREVIATION"] = normalized_df[candidate]
+                break
+    if "TEAM_ABBREVIATION" in normalized_df.columns:
+        normalized_df["TEAM_ABBREVIATION"] = (
+            normalized_df["TEAM_ABBREVIATION"].astype(str).str.strip()
+        )
+
+    if "TEAM_NAME" not in normalized_df.columns:
+        if {"TEAM_CITY_NAME", "TEAM_NICKNAME"}.issubset(normalized_df.columns):
+            normalized_df["TEAM_NAME"] = (
+                normalized_df["TEAM_CITY_NAME"].fillna("").str.strip()
+                + " "
+                + normalized_df["TEAM_NICKNAME"].fillna("").str.strip()
+            ).str.strip()
+        elif {"TEAM_CITY", "TEAM_NICKNAME"}.issubset(normalized_df.columns):
+            normalized_df["TEAM_NAME"] = (
+                normalized_df["TEAM_CITY"].fillna("").str.strip()
+                + " "
+                + normalized_df["TEAM_NICKNAME"].fillna("").str.strip()
+            ).str.strip()
+        elif "TEAM_NICKNAME" in normalized_df.columns:
+            normalized_df["TEAM_NAME"] = normalized_df["TEAM_NICKNAME"].fillna("").str.strip()
+
+    if "TEAM_NAME" in normalized_df.columns:
+        normalized_df["TEAM_NAME"] = normalized_df["TEAM_NAME"].astype(str).str.strip()
+
+    return normalized_df
+
+
+def _combine_summary_tables(resp, game_id: str) -> pd.DataFrame:
+    """Combina LineScore y OtherStats (si aplica) para ``BoxScoreSummaryV2``."""
+
+    data_sets = dict(_iter_endpoint_data_sets(resp))
+    line_score = data_sets.get("LineScore", pd.DataFrame())
+
+    if line_score.empty:
+        return _normalize_boxscore_team_columns(line_score, game_id)
+
+    other_stats = data_sets.get("OtherStats")
+    if other_stats is not None and not other_stats.empty and "TEAM_ID" in other_stats.columns:
+        other_stats = other_stats.drop_duplicates(subset=["TEAM_ID"])
+        merged = line_score.merge(other_stats, on="TEAM_ID", how="left", suffixes=("", "_other"))
+    else:
+        merged = line_score
+
+    return _normalize_boxscore_team_columns(merged, game_id)
+
+
+def _fetch_single_boxscore_team_df(
+    endpoint_class_name: str,
+    game_id: str,
+    *,
+    max_retries: int = 3,
+    sleep: float = 0.8,
+) -> Optional[pd.DataFrame]:
+    """Descarga y prepara el DataFrame de equipos para un endpoint concreto."""
+
+    cls = _get_endpoint_class(endpoint_class_name)
+    if cls is None:
+        logging.warning(
+            f"[skip] Endpoint no disponible en esta versión de nba_api: {endpoint_class_name}"
+        )
+        return None
+
+    for attempt in range(max_retries):
+        try:
+            response = _call_ep(cls, game_id=game_id)
+
+            if endpoint_class_name == "BoxScoreSummaryV2":
+                df = _combine_summary_tables(response, game_id)
+            else:
+                df = pd.DataFrame()
+                for name, table in _iter_endpoint_data_sets(response):
+                    if name.lower() == "teamstats":
+                        df = table
+                        break
+                df = _normalize_boxscore_team_columns(df, game_id)
+
+            if df.empty:
+                logging.warning(
+                    f"{endpoint_class_name}: DF vacío para GAME_ID {game_id}, se omite guardado"
+                )
+                return df
+
+            if len(df) != 2:
+                logging.error(
+                    f"{endpoint_class_name}: se esperaban 2 filas y se obtuvieron {len(df)}"
+                    f" para GAME_ID {game_id}"
+                )
+                return None
+
+            required_columns = {"GAME_ID", "TEAM_ID", "TEAM_ABBREVIATION", "TEAM_NAME"}
+            missing = required_columns.difference(df.columns)
+            if missing:
+                logging.error(
+                    f"{endpoint_class_name}: faltan columnas {sorted(missing)} en GAME_ID {game_id}"
+                )
+                return None
+
+            return df
+        except Exception as exc:
+            logging.warning(
+                f"Fallo en {endpoint_class_name} para GAME_ID {game_id} (intento {attempt + 1}/{max_retries}): {exc}"
+            )
+            time.sleep(sleep * (attempt + 1))
+
+    logging.error(
+        f"No se pudo descargar {endpoint_class_name} para GAME_ID {game_id} tras {max_retries} intentos"
+    )
+    return None
+
+
+def fetch_boxscore_team_data(
+    game_id: str,
+    *,
+    max_retries: int = 3,
+    sleep: float = 0.8,
+) -> Dict[str, pd.DataFrame]:
+    """Descarga todos los endpoints de boxscore de equipos para un ``GAME_ID``."""
+
+    results: Dict[str, pd.DataFrame] = {}
+
+    for endpoint_class_name in BOX_SCORE_TEAM_ENDPOINT_CLASSES:
+        df = _fetch_single_boxscore_team_df(
+            endpoint_class_name,
+            game_id,
+            max_retries=max_retries,
+            sleep=sleep,
+        )
+
+        if df is not None and not df.empty:
+            results[endpoint_class_name] = df
+
+        time.sleep(sleep)
+
+    return results
+
+
+def save_boxscore_team_parquet(
+    df: pd.DataFrame,
+    *,
+    season: str,
+    season_type: str,
+    game_id: str,
+    endpoint_name: str,
+    base_output_path: Optional[str] = None,
+) -> Dict[str, object]:
+    """Guarda un DataFrame de boxscore de equipos respetando la convención de nombres."""
+
+    if len(df) != 2:
+        raise ValueError(
+            f"El DataFrame para {endpoint_name} y GAME_ID {game_id} debe tener 2 filas"
+        )
+
+    required_columns = {"GAME_ID", "TEAM_ID", "TEAM_ABBREVIATION", "TEAM_NAME"}
+    missing = required_columns.difference(df.columns)
+    if missing:
+        raise ValueError(
+            f"Faltan columnas obligatorias {sorted(missing)} en {endpoint_name} (GAME_ID {game_id})"
+        )
+
+    output_root = base_output_path or BOX_SCORE_TEAMS_OUTPUT_ROOT
+    dir_path = os.path.join(output_root, season, season_type)
+    os.makedirs(dir_path, exist_ok=True)
+
+    filename = f"boxscore_teams__{game_id}__{endpoint_name}.parquet"
+    full_path = os.path.join(dir_path, filename)
+
+    df.to_parquet(full_path, index=False)
+
+    return {
+        "path": full_path,
+        "rows": len(df),
+        "endpoint": endpoint_name,
+        "game_id": game_id,
     }

--- a/01_data_scrapping/01a_scripts/_01a_function_tools.py
+++ b/01_data_scrapping/01a_scripts/_01a_function_tools.py
@@ -247,6 +247,11 @@ BOX_SCORE_TEAMS_OUTPUT_ROOT = (
 )
 
 
+# --- Compatibilidad SeasonTypeAllStar (algunas versiones usan "preseason") ---
+if not hasattr(SeasonTypeAllStar, "pre_season") and hasattr(SeasonTypeAllStar, "preseason"):
+    SeasonTypeAllStar.pre_season = getattr(SeasonTypeAllStar, "preseason")
+
+
 def _normalize_season_type_value(season_type: str) -> str:
     """Normaliza etiquetas de ``season_type`` según los valores esperados por la API."""
 

--- a/01_data_scrapping/01a_scripts/_01a_function_tools.py
+++ b/01_data_scrapping/01a_scripts/_01a_function_tools.py
@@ -358,6 +358,33 @@ def _normalize_boxscore_team_columns(df: pd.DataFrame, game_id: str) -> pd.DataF
     return normalized_df
 
 
+def _fallback_boxscore_team_table(resp) -> pd.DataFrame:
+    """Intenta localizar una tabla de equipos en la respuesta cuando falta TeamStats."""
+
+    if not resp:
+        return pd.DataFrame()
+
+    for name, table in _iter_endpoint_data_sets(resp):
+        if not isinstance(table, pd.DataFrame):
+            continue
+
+        if "TEAM_ID" in table.columns and len(table.columns) > 0:
+            return table
+
+    frames = []
+    if hasattr(resp, "get_data_frames"):
+        try:
+            frames = resp.get_data_frames() or []
+        except Exception:
+            frames = []
+
+    for table in frames:
+        if isinstance(table, pd.DataFrame) and "TEAM_ID" in table.columns:
+            return table
+
+    return pd.DataFrame()
+
+
 def _combine_summary_tables(resp, game_id: str) -> pd.DataFrame:
     """Combina LineScore y OtherStats (si aplica) para ``BoxScoreSummaryV2``."""
 
@@ -406,6 +433,11 @@ def _fetch_single_boxscore_team_df(
                         df = table
                         break
                 df = _normalize_boxscore_team_columns(df, game_id)
+
+                if df.empty:
+                    fallback_df = _fallback_boxscore_team_table(response)
+                    if not fallback_df.empty:
+                        df = _normalize_boxscore_team_columns(fallback_df, game_id)
 
             if df.empty:
                 logging.warning(

--- a/01_data_scrapping/01a_scripts/_01a_get_boxscores_teams.py
+++ b/01_data_scrapping/01a_scripts/_01a_get_boxscores_teams.py
@@ -1,0 +1,120 @@
+import argparse
+import logging
+from typing import Dict
+
+import pandas as pd
+
+from _01a_function_tools import (
+    fetch_boxscore_team_data,
+    list_team_game_ids_by_season_type,
+    save_boxscore_team_parquet,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _format_progress(index: int, total: int) -> str:
+    if total == 0:
+        return "0/0 (0.0%)"
+    pct = (index / total) * 100
+    return f"{index}/{total} ({pct:.1f}%)"
+
+
+def process_game(
+    game_id: str,
+    *,
+    season: str,
+    season_type: str,
+    sleep: float,
+    max_retries: int,
+) -> Dict[str, Dict[str, object]]:
+    datasets = fetch_boxscore_team_data(
+        game_id,
+        max_retries=max_retries,
+        sleep=sleep,
+    )
+
+    saved = {}
+
+    for endpoint_name, df in datasets.items():
+        if not isinstance(df, pd.DataFrame) or df.empty:
+            logger.warning(
+                f"GAME_ID {game_id} · {endpoint_name}: DataFrame vacío, se omite guardado"
+            )
+            continue
+
+        try:
+            result = save_boxscore_team_parquet(
+                df,
+                season=season,
+                season_type=season_type,
+                game_id=game_id,
+                endpoint_name=endpoint_name,
+            )
+            saved[endpoint_name] = result
+        except Exception as exc:
+            logger.error(
+                f"GAME_ID {game_id} · {endpoint_name}: error guardando parquet → {exc}"
+            )
+
+    return saved
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Descarga boxscores de equipo (home/away) por partido.",
+    )
+    parser.add_argument("--season", required=True, help="Formato '2024-25'")
+    parser.add_argument(
+        "--season_type",
+        required=True,
+        help="Regular Season, Playoffs o PlayIn",
+    )
+    parser.add_argument("--sleep", type=float, default=0.8, help="Pausa entre llamadas")
+    parser.add_argument("--max-retries", type=int, default=3, help="Reintentos por endpoint")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+
+    game_ids = list_team_game_ids_by_season_type(args.season, args.season_type)
+    total_games = len(game_ids)
+
+    if total_games == 0:
+        logger.warning(
+            f"{args.season} · {args.season_type}: no se encontraron GAME_ID para procesar"
+        )
+        return
+
+    logger.info(
+        f"{args.season} · {args.season_type}: se procesarán {total_games} partidos"
+    )
+
+    for index, game_id in enumerate(game_ids, start=1):
+        try:
+            saved = process_game(
+                game_id,
+                season=args.season,
+                season_type=args.season_type,
+                sleep=args.sleep,
+                max_retries=args.max_retries,
+            )
+        except Exception as exc:
+            logger.error(f"GAME_ID {game_id}: error inesperado → {exc}")
+            continue
+
+        if not saved:
+            logger.warning(
+                f"GAME_ID {game_id}: no se guardaron endpoints de equipos"
+            )
+        else:
+            logger.info(
+                (
+                    f"GAME_ID {game_id}: guardados {len(saved)} endpoints"
+                    f" ({', '.join(sorted(saved))}) · "
+                    f"Progreso { _format_progress(index, total_games) }"
+                )
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/01_data_scrapping/01a_scripts/_01a_get_boxscores_teams.py
+++ b/01_data_scrapping/01a_scripts/_01a_get_boxscores_teams.py
@@ -1,6 +1,6 @@
 import argparse
 import logging
-from typing import Dict
+from typing import Dict, List
 
 import pandas as pd
 
@@ -18,6 +18,57 @@ def _format_progress(index: int, total: int) -> str:
         return "0/0 (0.0%)"
     pct = (index / total) * 100
     return f"{index}/{total} ({pct:.1f}%)"
+
+
+def _split_csv_argument(raw_value: str) -> List[str]:
+    return [value.strip() for value in raw_value.split(",") if value.strip()]
+
+
+def _resolve_seasons(args: argparse.Namespace, parser: argparse.ArgumentParser) -> List[str]:
+    if args.seasons and args.season:
+        parser.error("No combines --season con --seasons")
+
+    if args.seasons:
+        seasons = _split_csv_argument(args.seasons)
+    elif args.season:
+        seasons = [args.season.strip()]
+    else:
+        parser.error("Debes indicar --season o --seasons")
+
+    if not seasons:
+        parser.error("La lista de temporadas está vacía")
+
+    return list(dict.fromkeys(seasons))
+
+
+def _resolve_season_types(
+    args: argparse.Namespace, parser: argparse.ArgumentParser
+) -> List[str]:
+    if args.season_types and args.season_type:
+        parser.error("No combines --season-type con --season-types")
+
+    if args.playoffs_only and args.regular_only:
+        parser.error("No puedes combinar --playoffs-only y --regular-only")
+
+    if args.season_types:
+        season_types = _split_csv_argument(args.season_types)
+    elif args.season_type:
+        season_types = [args.season_type.strip()]
+    else:
+        season_types = []
+        if not args.playoffs_only:
+            season_types.append("Regular Season")
+        if args.include_playoffs or args.playoffs_only:
+            season_types.append("Playoffs")
+        if args.regular_only:
+            season_types = ["Regular Season"]
+        if args.playoffs_only:
+            season_types = ["Playoffs"]
+
+    if not season_types:
+        parser.error("No hay season_types válidos para procesar")
+
+    return list(dict.fromkeys(season_types))
 
 
 def process_game(
@@ -60,45 +111,39 @@ def process_game(
     return saved
 
 
-def main():
-    parser = argparse.ArgumentParser(
-        description="Descarga boxscores de equipo (home/away) por partido.",
-    )
-    parser.add_argument("--season", required=True, help="Formato '2024-25'")
-    parser.add_argument(
-        "--season_type",
-        required=True,
-        help="Regular Season, Playoffs o PlayIn",
-    )
-    parser.add_argument("--sleep", type=float, default=0.8, help="Pausa entre llamadas")
-    parser.add_argument("--max-retries", type=int, default=3, help="Reintentos por endpoint")
-    args = parser.parse_args()
-
-    logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
-
-    game_ids = list_team_game_ids_by_season_type(args.season, args.season_type)
+def process_season_type(
+    *,
+    season: str,
+    season_type: str,
+    sleep: float,
+    max_retries: int,
+) -> Dict[str, object]:
+    game_ids = list_team_game_ids_by_season_type(season, season_type)
     total_games = len(game_ids)
 
     if total_games == 0:
         logger.warning(
-            f"{args.season} · {args.season_type}: no se encontraron GAME_ID para procesar"
+            f"{season} · {season_type}: no se encontraron GAME_ID para procesar"
         )
-        return
+        return {"total_games": 0, "failed_games": 0}
 
     logger.info(
-        f"{args.season} · {args.season_type}: se procesarán {total_games} partidos"
+        f"{season} · {season_type}: se procesarán {total_games} partidos"
     )
+
+    failed_games = 0
 
     for index, game_id in enumerate(game_ids, start=1):
         try:
             saved = process_game(
                 game_id,
-                season=args.season,
-                season_type=args.season_type,
-                sleep=args.sleep,
-                max_retries=args.max_retries,
+                season=season,
+                season_type=season_type,
+                sleep=sleep,
+                max_retries=max_retries,
             )
         except Exception as exc:
+            failed_games += 1
             logger.error(f"GAME_ID {game_id}: error inesperado → {exc}")
             continue
 
@@ -114,6 +159,57 @@ def main():
                     f"Progreso { _format_progress(index, total_games) }"
                 )
             )
+
+    logger.info(
+        (
+            f"{season} · {season_type}: procesamiento finalizado. "
+            f"Partidos con error: {failed_games}/{total_games}"
+        )
+    )
+
+    return {"total_games": total_games, "failed_games": failed_games}
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Descarga boxscores de equipo (home/away) por partido.",
+    )
+    parser.add_argument("--season", help="Formato '2024-25'")
+    parser.add_argument("--seasons", help="Formato '2024-25,2025-26'")
+    parser.add_argument(
+        "--season_type",
+        help="Regular Season, Playoffs o PlayIn",
+    )
+    parser.add_argument(
+        "--season-types",
+        help="Lista separada por comas de season types a procesar",
+    )
+    parser.add_argument("--include-playoffs", action="store_true")
+    parser.add_argument("--regular-only", action="store_true")
+    parser.add_argument("--playoffs-only", action="store_true")
+    parser.add_argument("--sleep", type=float, default=0.8, help="Pausa entre llamadas")
+    parser.add_argument("--max-retries", type=int, default=3, help="Reintentos por endpoint")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+
+    seasons = _resolve_seasons(args, parser)
+    season_types = _resolve_season_types(args, parser)
+
+    exit_code = 0
+
+    for season in seasons:
+        for season_type in season_types:
+            result = process_season_type(
+                season=season,
+                season_type=season_type,
+                sleep=args.sleep,
+                max_retries=args.max_retries,
+            )
+            if result.get("failed_games"):
+                exit_code = 1
+
+    raise SystemExit(exit_code)
 
 
 if __name__ == "__main__":

--- a/01_data_scrapping/01a_scripts/_01b_downloader_total.py
+++ b/01_data_scrapping/01a_scripts/_01b_downloader_total.py
@@ -29,6 +29,13 @@ TASKS = [
     },
 
     {
+        "name": "Box Scores Equipos (home/away)",
+        "rel_path": "_01a_get_boxscores_teams.py",
+        "enabled": False,
+        "extra_args": [],
+    },
+
+    {
         "name": "Team Dashboards",
         "rel_path": "_01a_get_team_dashboards.py",
         "enabled": True,


### PR DESCRIPTION
## Summary
- add utilities for downloading and normalising team-level boxscore datasets and saving them to parquet with the required naming convention
- create a command line script to orchestrate per-game downloads for a season and season type using the new helpers

## Testing
- python -m compileall 01_data_scrapping/01a_scripts/_01a_function_tools.py 01_data_scrapping/01a_scripts/_01a_get_boxscores_teams.py

------
https://chatgpt.com/codex/tasks/task_e_68e2738e8a5883208b0bf8d2f25627f0