### PR TITLE
Handle missing offensive matchup columns gracefully

### DIFF
--- a/basketball_analysis/__init__.py
+++ b/basketball_analysis/__init__.py
@@ -1,0 +1,5 @@
+"""Utility helpers for BasketballAnalysis data pipelines."""
+
+from .matchups import _transform_matchups
+
+__all__ = ["_transform_matchups"]

--- a/basketball_analysis/matchups.py
+++ b/basketball_analysis/matchups.py
@@ -1,0 +1,81 @@
+"""Utilities to normalise box score matchup tables."""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict, Iterable, Mapping, Sequence
+
+try:  # pragma: no cover - exercised via tests when pandas is available
+    import pandas as pd
+except ImportError:  # pragma: no cover - best effort fallback for environments without pandas
+    pd = None  # type: ignore[assignment]
+
+LOGGER = logging.getLogger(__name__)
+
+_MATCHUP_RENAME_TEMPLATE: Mapping[str, str] = {
+    "OFF_TEAM_ID": "TEAM_ID",
+    "OFF_TEAM_ABBREVIATION": "TEAM_ABBREVIATION",
+    "OFF_TEAM_CITY": "TEAM_CITY",
+    "OFF_TEAM_NAME": "TEAM_NAME",
+    "OFF_TEAM_NICKNAME": "TEAM_NICKNAME",
+    "OFF_TEAM_SLUG": "TEAM_SLUG",
+    "OFF_PLAYER_ID": "PLAYER_ID",
+    "OFF_PLAYER_FIRST_NAME": "PLAYER_FIRST_NAME",
+    "OFF_PLAYER_LAST_NAME": "PLAYER_LAST_NAME",
+    "OFF_PLAYER_NAME": "PLAYER_NAME",
+    "OFF_PLAYER_NUMBER": "PLAYER_NUMBER",
+    "OFF_PLAYER_POSITION": "PLAYER_POSITION",
+    "OFF_PLAYER_SLUG": "PLAYER_SLUG",
+}
+
+_REQUIRED_COLUMNS: Sequence[str] = ("GAME_ID", "TEAM_ID", "PLAYER_ID")
+
+
+def _build_matchup_rename_map(columns: Iterable[str]) -> Dict[str, str]:
+    """Return a rename map keeping only keys present in ``columns``."""
+
+    return {key: value for key, value in _MATCHUP_RENAME_TEMPLATE.items() if key in columns}
+
+
+def _transform_matchups(df: "pd.DataFrame") -> "pd.DataFrame":
+    """Normalise offensive matchup columns to the shared schema.
+
+    Parameters
+    ----------
+    df:
+        Raw dataframe returned by ``BoxScoreMatchupsV3``. The function performs
+        a best-effort rename of ``OFF_*`` columns so the offensive team/player
+        fields align with the standard box-score schema. Only columns that are
+        present in ``df`` are renamed, allowing matchups without optional
+        metadata (nickname, city, etc.) to be processed without raising errors.
+
+    Returns
+    -------
+    pandas.DataFrame
+        A copy of ``df`` with the available offensive columns renamed. The
+        function validates that ``GAME_ID``, ``TEAM_ID`` and ``PLAYER_ID`` exist
+        after the rename, raising ``KeyError`` if any of them are missing.
+    """
+
+    if pd is None:  # pragma: no cover - executed only when pandas is missing
+        raise ImportError("pandas is required to transform matchups data")
+
+    if df.empty:
+        return df.copy()
+
+    rename_map = _build_matchup_rename_map(df.columns)
+    transformed = df.rename(columns=rename_map).copy()
+
+    missing_required = [column for column in _REQUIRED_COLUMNS if column not in transformed.columns]
+    if missing_required:
+        message = (
+            "Matchups frame is missing required columns after renaming: "
+            + ", ".join(sorted(missing_required))
+        )
+        LOGGER.error(message)
+        raise KeyError(message)
+
+    return transformed
+
+
+__all__ = ["_transform_matchups"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,68 @@
+import sys
+import types
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+ROOT_STR = str(ROOT_DIR)
+if ROOT_STR not in sys.path:
+    sys.path.insert(0, ROOT_STR)
+
+try:  # pragma: no cover - executed when pandas is available
+    import pandas  # noqa: F401  # pragma: no cover
+except ModuleNotFoundError:  # pragma: no cover - lightweight stub for offline envs
+    stub = types.ModuleType("pandas")
+
+    class DataFrame:  # pragma: no cover - behaviour verified via tests
+        def __init__(self, data):
+            self._columns = list(data.keys())
+            values = [list(column_values) for column_values in data.values()]
+            if values:
+                length = {len(column) for column in values}
+                if len(length) != 1:
+                    raise ValueError("All columns must share the same length")
+                row_count = length.pop()
+                self._rows = [
+                    {column: values[idx][row] for idx, column in enumerate(self._columns)}
+                    for row in range(row_count)
+                ]
+            else:
+                self._rows = []
+
+        @property
+        def columns(self):
+            return list(self._columns)
+
+        @property
+        def empty(self):
+            return len(self._rows) == 0
+
+        def copy(self):
+            data = {column: [row[column] for row in self._rows] for column in self._columns}
+            return DataFrame(data)
+
+        def rename(self, *, columns):
+            renamed_data = {}
+            for column in self._columns:
+                new_name = columns.get(column, column)
+                renamed_data[new_name] = [row[column] for row in self._rows]
+            return DataFrame(renamed_data)
+
+        def equals(self, other):
+            if not isinstance(other, DataFrame):
+                return False
+            return self._columns == other._columns and self._rows == other._rows
+
+        class _LocAccessor:
+            def __init__(self, frame):
+                self._frame = frame
+
+            def __getitem__(self, key):
+                row_idx, column = key
+                return self._frame._rows[row_idx][column]
+
+        @property
+        def loc(self):
+            return DataFrame._LocAccessor(self)
+
+    stub.DataFrame = DataFrame
+    sys.modules["pandas"] = stub

--- a/tests/test_matchups_transform.py
+++ b/tests/test_matchups_transform.py
@@ -1,0 +1,50 @@
+import pytest
+
+pd = pytest.importorskip("pandas")
+
+from basketball_analysis.matchups import _transform_matchups
+
+
+def test_transform_matchups_keeps_required_columns_with_partial_off_fields():
+    df = pd.DataFrame(
+        {
+            "GAME_ID": ["0022400001"],
+            "OFF_TEAM_ID": [1610612737],
+            "OFF_PLAYER_ID": [203500],
+            "OFF_PLAYER_NAME": ["Test Player"],
+            "OFF_PLAYER_FIRST_NAME": ["Test"],
+            "OFF_PLAYER_LAST_NAME": ["Player"],
+            # Optional metadata intentionally missing (city, nickname, etc.).
+            "MATCHUP_MINUTES": [12.5],
+        }
+    )
+
+    transformed = _transform_matchups(df)
+
+    assert transformed.loc[0, "TEAM_ID"] == 1610612737
+    assert transformed.loc[0, "PLAYER_ID"] == 203500
+    assert "OFF_TEAM_ID" not in transformed.columns
+    assert "OFF_PLAYER_NAME" not in transformed.columns
+    assert transformed.loc[0, "MATCHUP_MINUTES"] == pytest.approx(12.5)
+
+
+def test_transform_matchups_accepts_existing_required_columns():
+    df = pd.DataFrame(
+        {
+            "GAME_ID": ["0022400002"],
+            "TEAM_ID": [1610612738],
+            "PLAYER_ID": [2544],
+            "SOME_OTHER_COLUMN": [1],
+        }
+    )
+
+    transformed = _transform_matchups(df)
+
+    assert transformed.equals(df)
+
+
+def test_transform_matchups_raises_when_required_columns_missing():
+    df = pd.DataFrame({"OFF_TEAM_ID": [1], "OFF_PLAYER_ID": [2]})
+
+    with pytest.raises(KeyError):
+        _transform_matchups(df)


### PR DESCRIPTION
## Summary
- add a matchup transformer that renames only the offensive columns present and checks for required identifiers
- expose the helper at the package level for reuse by data pipelines
- add pytest coverage (with a lightweight pandas stub) to ensure partial matchup payloads succeed and missing IDs fail fast

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e58838d8cc8320a2f93510a210a6a2