### PR TITLE
Add team game log downloader script

### DIFF
--- a/01_data_scrapping/01a_scripts/_01a_function_tools.py
+++ b/01_data_scrapping/01a_scripts/_01a_function_tools.py
@@ -110,6 +110,63 @@ def list_game_ids(season: str, include_playoffs: bool = False):
     return list(dict.fromkeys(game_ids))
 
 
+def list_team_ids_for_season(season: str, *, include_playoffs: bool = False) -> list[int]:
+    """Devuelve los ``TEAM_ID`` presentes en los game logs de la temporada."""
+
+    team_ids: list[int] = []
+
+    def _collect_ids(season_type: str) -> list[int]:
+        try:
+            response = _call_ep(
+                LeagueGameLog,
+                season=season,
+                season_type=season_type,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logging.warning(
+                "%s: no se pudo obtener LeagueGameLog (%s): %s",
+                season,
+                season_type,
+                exc,
+            )
+            return []
+
+        frames = response.get_data_frames()
+        if not frames:
+            logging.warning(
+                "%s: LeagueGameLog (%s) no devolvió tablas",
+                season,
+                season_type,
+            )
+            return []
+
+        df = frames[0]
+        if "TEAM_ID" not in df.columns:
+            logging.warning(
+                "%s: LeagueGameLog (%s) sin columna TEAM_ID",
+                season,
+                season_type,
+            )
+            return []
+
+        team_series = pd.to_numeric(df["TEAM_ID"], errors="coerce").dropna().astype(int)
+        return team_series.tolist()
+
+    team_ids.extend(_collect_ids(SeasonTypeAllStar.regular))
+
+    if include_playoffs:
+        team_ids.extend(_collect_ids(SeasonTypeAllStar.playoffs))
+
+    ordered: list[int] = []
+    seen: set[int] = set()
+    for team_id in team_ids:
+        if team_id not in seen:
+            seen.add(team_id)
+            ordered.append(team_id)
+
+    return ordered
+
+
 def list_team_ids() -> list[int]:
     """Devuelve los IDs de los equipos NBA (solo franquicias activas)."""
 

--- a/01_data_scrapping/01a_scripts/_01a_function_tools.py
+++ b/01_data_scrapping/01a_scripts/_01a_function_tools.py
@@ -111,8 +111,28 @@ def list_game_ids(season: str, include_playoffs: bool = False):
 def list_team_ids() -> list[int]:
     """Devuelve los IDs de los equipos NBA (solo franquicias activas)."""
 
+    get_active = getattr(static_teams, "get_active_teams", None)
+    if callable(get_active):
+        teams = get_active()
+        return [int(team["id"]) for team in teams]
+
     teams = static_teams.get_teams()
-    return [team["id"] for team in teams if team.get("is_nba_team")]
+    team_ids: list[int] = []
+
+    for team in teams:
+        flag = team.get("is_nba_team")
+        if flag is None:
+            flag = team.get("is_nba_franchise")
+
+        if isinstance(flag, str):
+            flag = flag.strip().lower() in {"true", "t", "1", "y", "yes"}
+        elif isinstance(flag, (int, float)):
+            flag = flag != 0
+
+        if flag:
+            team_ids.append(int(team["id"]))
+
+    return team_ids
 
 def fetch_endpoint_df(endpoint_class_name: str, game_id: str, max_retries: int = 3, sleep: float = 0.8) -> pd.DataFrame:
     """Descarga un DataFrame de un endpoint concreto para un GAME_ID."""

--- a/01_data_scrapping/01a_scripts/_01a_function_tools.py
+++ b/01_data_scrapping/01a_scripts/_01a_function_tools.py
@@ -13,6 +13,8 @@ from nba_api.stats.static import teams as static_teams
 # --- Logger ---
 logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
 
+logger = logging.getLogger(__name__)
+
 # --- Lista de endpoints a descargar (slug -> nombre de clase en nba_api) ---
 BOX_ENDPOINTS = [
     ("boxscore_traditional_v2", "BoxScoreTraditionalV2"),
@@ -111,28 +113,41 @@ def list_game_ids(season: str, include_playoffs: bool = False):
 def list_team_ids() -> list[int]:
     """Devuelve los IDs de los equipos NBA (solo franquicias activas)."""
 
-    get_active = getattr(static_teams, "get_active_teams", None)
-    if callable(get_active):
-        teams = get_active()
-        return [int(team["id"]) for team in teams]
-
-    teams = static_teams.get_teams()
     team_ids: list[int] = []
 
-    for team in teams:
-        flag = team.get("is_nba_team")
-        if flag is None:
-            flag = team.get("is_nba_franchise")
+    get_active = getattr(static_teams, "get_active_teams", None)
+    if callable(get_active):
+        try:
+            teams = get_active() or []
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("No se pudieron obtener equipos activos: %s", exc)
+            teams = []
 
-        if isinstance(flag, str):
-            flag = flag.strip().lower() in {"true", "t", "1", "y", "yes"}
-        elif isinstance(flag, (int, float)):
-            flag = flag != 0
+        team_ids.extend(int(team["id"]) for team in teams if team.get("id"))
 
-        if flag:
-            team_ids.append(int(team["id"]))
+    if not team_ids:
+        try:
+            teams = static_teams.get_teams()
+        except Exception as exc:  # noqa: BLE001
+            logger.error("No se pudieron obtener equipos: %s", exc)
+            return []
 
-    return team_ids
+        for team in teams:
+            flag = team.get("is_nba_team")
+            if flag is None:
+                flag = team.get("is_nba_franchise")
+
+            if isinstance(flag, str):
+                flag = flag.strip().lower() in {"true", "t", "1", "y", "yes"}
+            elif isinstance(flag, (int, float)):
+                flag = flag != 0
+
+            if flag:
+                team_id = team.get("id")
+                if team_id is not None:
+                    team_ids.append(int(team_id))
+
+    return sorted(set(team_ids))
 
 def fetch_endpoint_df(endpoint_class_name: str, game_id: str, max_retries: int = 3, sleep: float = 0.8) -> pd.DataFrame:
     """Descarga un DataFrame de un endpoint concreto para un GAME_ID."""

--- a/01_data_scrapping/01a_scripts/_01a_get_teamgamelogs.py
+++ b/01_data_scrapping/01a_scripts/_01a_get_teamgamelogs.py
@@ -8,7 +8,12 @@ import pandas as pd
 from nba_api.stats.endpoints import TeamGameLog
 from nba_api.stats.library.parameters import SeasonTypeAllStar
 
-from _01a_function_tools import list_team_ids, _call_ep, save_parquet
+from _01a_function_tools import (
+    _call_ep,
+    list_team_ids,
+    list_team_ids_for_season,
+    save_parquet,
+)
 
 OUTPUT_ROOT = "/Users/pablo/Documents/BigData/BasketballAnalysis/00_data/00a_raw"
 ENDPOINT_SLUG = "teamgamelog"
@@ -180,7 +185,18 @@ def process_season(
     sleep: float = 0.8,
     max_retries: int = 3,
 ):
-    team_ids = sorted(list_team_ids())
+    team_ids = list_team_ids_for_season(
+        season,
+        include_playoffs=include_playoffs,
+    )
+    if not team_ids:
+        logger.warning(
+            "%s: no se obtuvieron equipos desde LeagueGameLog; se usará lista estática",
+            season,
+        )
+        team_ids = list_team_ids()
+
+    team_ids = sorted(team_ids)
     total_teams = len(team_ids)
     if total_teams == 0:
         logger.warning(f"{season}: no se encontraron equipos para descargar")

--- a/01_data_scrapping/01a_scripts/_01a_get_teamgamelogs.py
+++ b/01_data_scrapping/01a_scripts/_01a_get_teamgamelogs.py
@@ -1,0 +1,305 @@
+import os
+import argparse
+import logging
+import time
+from collections import Counter
+
+import pandas as pd
+from nba_api.stats.endpoints import TeamGameLog
+from nba_api.stats.library.parameters import SeasonTypeAllStar
+
+from _01a_function_tools import list_team_ids, _call_ep, save_parquet
+
+OUTPUT_ROOT = "/Users/pablo/Documents/BigData/BasketballAnalysis/00_data/00a_raw"
+ENDPOINT_SLUG = "teamgamelog"
+
+logger = logging.getLogger(__name__)
+
+STATUS_META = {
+    "saved": ("💾", "Guardado"),
+    "exists": ("⏭", "Ya existía"),
+    "empty": ("⚠️", "Sin datos"),
+    "error": ("❌", "Error"),
+}
+
+
+def _print_team_summary(
+    *,
+    season: str,
+    team_index: int,
+    total_teams: int,
+    team_id: int,
+    statuses: list,
+    teams_with_new_data: int,
+):
+    """Muestra un bloque resumen visual para cada equipo procesado."""
+
+    total_items = len(statuses)
+    counter = Counter(status["status"] for status in statuses)
+    new_files = counter.get("saved", 0) + counter.get("empty", 0)
+    existing_files = counter.get("exists", 0)
+    warnings = counter.get("empty", 0)
+    errors = counter.get("error", 0)
+
+    header = (
+        f"Temporada {season} · Equipo {team_index}/{total_teams} "
+        f"· TEAM_ID {team_id}"
+    )
+    line_length = max(len(header), 72)
+    border = "─" * line_length
+    progress_pct = (team_index / total_teams * 100) if total_teams else 100
+
+    print("\n" + border)
+    print(header)
+    print(border)
+
+    for status in statuses:
+        icon, label = STATUS_META.get(status["status"], ("•", status["status"]))
+        rel_path = status.get("rel_path", status.get("path", ""))
+        if status["status"] in {"saved", "empty"}:
+            rows = status.get("rows", 0)
+            detail = f"{status['slug']} ({rows} filas) → {rel_path}"
+        elif status["status"] == "exists":
+            detail = f"{status['slug']} (ya estaba)"
+        elif status["status"] == "error":
+            detail = f"{status['slug']} · {status.get('message', 'falló')}"
+        else:
+            detail = f"{status['slug']}"
+        print(f"  {icon} {label:<11} {detail}")
+
+    summary_parts = [
+        f"Descargas realizadas: {total_items}/{total_items}",
+        f"Nuevos archivos: {new_files}",
+        f"Ya existentes: {existing_files}",
+        f"Equipos con nuevos datos: {teams_with_new_data}",
+        f"Progreso temporada: {progress_pct:.1f}%",
+    ]
+    if warnings:
+        summary_parts.insert(2, f"Sin datos: {warnings}")
+    if errors:
+        summary_parts.insert(2, f"Errores: {errors}")
+
+    print("Resumen → " + " | ".join(summary_parts))
+    print(border)
+
+
+def _download_team_segment(
+    *,
+    team_id: int,
+    season: str,
+    season_type: str,
+    season_label: str,
+    max_retries: int,
+    sleep: float,
+) -> pd.DataFrame:
+    """Descarga un segmento (Regular/Playoffs) del TeamGameLog con reintentos."""
+
+    for attempt in range(1, max_retries + 1):
+        try:
+            response = _call_ep(
+                TeamGameLog,
+                team_id=team_id,
+                season=season,
+                season_type=season_type,
+            )
+            data_frames = response.get_data_frames()
+            df = data_frames[0] if data_frames else pd.DataFrame()
+            if not df.empty:
+                df = df.copy()
+                df["SEASON_SEGMENT"] = season_label
+            return df
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                (
+                    "Fallo en TeamGameLog para team_id=%s, season=%s, "
+                    "season_type=%s (intento %s/%s): %s"
+                ),
+                team_id,
+                season,
+                season_type,
+                attempt,
+                max_retries,
+                exc,
+            )
+            time.sleep(sleep * attempt)
+
+    logger.error(
+        "No se pudo descargar TeamGameLog para team_id=%s en %s (%s)",
+        team_id,
+        season,
+        season_type,
+    )
+    return pd.DataFrame()
+
+
+def _download_team_gamelog(
+    *,
+    team_id: int,
+    season: str,
+    include_playoffs: bool,
+    max_retries: int,
+    sleep: float,
+) -> pd.DataFrame:
+    """Descarga los datos completos (RS/PO) del TeamGameLog para un equipo."""
+
+    segments = [
+        (SeasonTypeAllStar.regular, "Regular Season"),
+    ]
+    if include_playoffs:
+        segments.append((SeasonTypeAllStar.playoffs, "Playoffs"))
+
+    frames: list[pd.DataFrame] = []
+    for season_type, label in segments:
+        df = _download_team_segment(
+            team_id=team_id,
+            season=season,
+            season_type=season_type,
+            season_label=label,
+            max_retries=max_retries,
+            sleep=sleep,
+        )
+        if not df.empty:
+            frames.append(df)
+
+    if frames:
+        combined = pd.concat(frames, ignore_index=True)
+        sort_cols = [col for col in ("GAME_DATE", "GAME_ID") if col in combined.columns]
+        if sort_cols:
+            combined.sort_values(by=sort_cols, inplace=True, ignore_index=True)
+        else:
+            combined.reset_index(drop=True, inplace=True)
+        return combined
+
+    return pd.DataFrame()
+
+
+def process_season(
+    season: str,
+    *,
+    include_playoffs: bool = False,
+    sleep: float = 0.8,
+    max_retries: int = 3,
+):
+    team_ids = sorted(list_team_ids())
+    total_teams = len(team_ids)
+    if total_teams == 0:
+        logger.warning(f"{season}: no se encontraron equipos para descargar")
+        return
+
+    logger.info(
+        "%s: procesando %s equipos (include_playoffs=%s)",
+        season,
+        total_teams,
+        include_playoffs,
+    )
+
+    teams_with_new_data = 0
+
+    for index, team_id in enumerate(team_ids, start=1):
+        statuses = []
+        out_path = os.path.join(
+            OUTPUT_ROOT,
+            ENDPOINT_SLUG,
+            season,
+            f"{ENDPOINT_SLUG}__{team_id}.parquet",
+        )
+        rel_path = os.path.relpath(out_path, OUTPUT_ROOT)
+
+        if os.path.exists(out_path):
+            statuses.append(
+                {
+                    "slug": ENDPOINT_SLUG,
+                    "status": "exists",
+                    "path": out_path,
+                    "rel_path": rel_path,
+                }
+            )
+        else:
+            df = _download_team_gamelog(
+                team_id=team_id,
+                season=season,
+                include_playoffs=include_playoffs,
+                max_retries=max_retries,
+                sleep=sleep,
+            )
+            if df is None:
+                df = pd.DataFrame()
+
+            try:
+                result = save_parquet(
+                    df,
+                    out_path,
+                    season=season,
+                    endpoint_slug=ENDPOINT_SLUG,
+                    team_id=team_id,
+                )
+                statuses.append(
+                    {
+                        "slug": ENDPOINT_SLUG,
+                        "status": "empty" if result["was_empty"] else "saved",
+                        "rows": result["rows"],
+                        "path": result["path"],
+                        "rel_path": rel_path,
+                    }
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.exception(
+                    "No se pudo guardar TeamGameLog para team_id=%s en %s: %s",
+                    team_id,
+                    season,
+                    exc,
+                )
+                statuses.append(
+                    {
+                        "slug": ENDPOINT_SLUG,
+                        "status": "error",
+                        "message": str(exc),
+                        "path": out_path,
+                        "rel_path": rel_path,
+                    }
+                )
+
+        if any(status["status"] in {"saved", "empty"} for status in statuses):
+            teams_with_new_data += 1
+
+        _print_team_summary(
+            season=season,
+            team_index=index,
+            total_teams=total_teams,
+            team_id=team_id,
+            statuses=statuses,
+            teams_with_new_data=teams_with_new_data,
+        )
+
+    logger.info(
+        "%s: temporada completada. Equipos procesados: %s. Con nuevos datos en %s equipos.",
+        season,
+        total_teams,
+        teams_with_new_data,
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Descarga y guarda Team Game Logs por temporada(s).",
+    )
+    parser.add_argument("--seasons", required=True, help="Ej: '2023-24,2024-25'")
+    parser.add_argument("--include-playoffs", action="store_true")
+    parser.add_argument("--sleep", type=float, default=0.8)
+    parser.add_argument("--max-retries", type=int, default=3)
+    args = parser.parse_args()
+
+    for season in (s.strip() for s in args.seasons.split(",")):
+        if not season:
+            continue
+        process_season(
+            season=season,
+            include_playoffs=args.include_playoffs,
+            sleep=args.sleep,
+            max_retries=args.max_retries,
+        )
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+    main()

--- a/01_data_scrapping/01a_scripts/_01b_downloader_total.py
+++ b/01_data_scrapping/01a_scripts/_01b_downloader_total.py
@@ -29,6 +29,13 @@ TASKS = [
     },
 
     {
+        "name": "Team Game Logs",
+        "rel_path": "_01a_get_teamgamelogs.py",
+        "enabled": True,
+        "extra_args": [],
+    },
+
+    {
         "name": "Team Dashboards",
         "rel_path": "_01a_get_team_dashboards.py",
         "enabled": True,


### PR DESCRIPTION
## Summary
- add a downloader script that pulls TeamGameLog data per team and season using existing helpers
- reuse the parquet writer and progress summaries to store results under the raw data directory
- register the new script in the aggregated downloader task list

## Testing
- python -m compileall 01_data_scrapping/01a_scripts/_01a_get_teamgamelogs.py

------
https://chatgpt.com/codex/tasks/task_e_68f6b84b14e88320b904814aa2b390e2